### PR TITLE
Remove all mentions of compatibility or classic modes

### DIFF
--- a/tests/examples.py
+++ b/tests/examples.py
@@ -180,9 +180,9 @@ DEGENERATE_EXAMPLES = [
      '#t'),
     ('(get "wikipedia-term" "Purchasing power parity" (:calculated "PROPER"))',
      '#f'),
-    ('(get "Lamb of God (band)" "PROPER")',
+    ('(get "wikipedia-musical-artist" "Lamb of God (band)" "PROPER")',
      '#t'),
-    ('(get "Board game" "PROPER")',
+    ('(get "wikipedia-term" "Board game" "PROPER")',
      '#f'),
 
     # This means plural or singular I guess

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -43,7 +43,8 @@ class TestArticle(unittest.TestCase):
     def test_complex(self):
         article = Article("Baal", self.fetcher)
         self.assertEqual(article.headings()[-1], "External links")
-        self.assertEqual(len(list(article.headings())), 17)
+        # TODO : is this a good test? The number of headings keeps changing
+        self.assertEqual(len(list(article.headings())), 21)
 
     # XXX: symbols are not used anyway but here is the test.
     # The symbols work, mocking

--- a/tests/test_paragraph.py
+++ b/tests/test_paragraph.py
@@ -14,7 +14,6 @@ except ImportError:
     import unittest
 
 from wikipediabase import wikipediabase
-from wikipediabase.fetcher import WIKIBASE_FETCHER
 
 
 class TestParagraph(unittest.TestCase):
@@ -23,9 +22,9 @@ class TestParagraph(unittest.TestCase):
         pass
 
     def test_first_paren(self):
-        self.assertEqual(wikipediabase('(get "Mary Shakespeare" "birth-date")',
-                                       fetcher=WIKIBASE_FETCHER),
-                         "((:yyyymmdd 15370000))")
+        self.assertEqual(wikipediabase(
+            '(get "wikipedia-person" "Mary Shakespeare" "birth-date")'),
+            "((:yyyymmdd 15370000))")
 
     def tearDown(self):
         pass

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -70,13 +70,11 @@ class TestResolvers(unittest.TestCase):
                       str(self.simple_resolver.resolve("Barack obama", "url")))
 
     def test_infobox(self):
-        # Disable compatibility mode: no extra tag info on result.
-        self.ibresolver.compat = False
-
-        band_name = self.fe.eval('(get "%s" "Name")' % "Def_Leppard_EP")
+        band_name = self.fe.eval('(get "wikipedia-album" "%s" "Name")' %
+                                 "Def_Leppard_EP")
         self.assertEqual(band_name, '((:html "The Def Leppard E.P."))')
 
-    def test_compat(self):
+    def test_get(self):
         for ans, rx, msg in self._ans_match(WIKI_EXAMPLES):
             self.assertEqual(ans, rx, msg=msg)
 
@@ -84,15 +82,15 @@ class TestResolvers(unittest.TestCase):
         for ans, rx, msg in self._ans_match(DEGENERATE_EXAMPLES, All()):
             self.assertEqual(ans, rx, msg=msg)
 
-    def test_compat_not(self):
+    def test_get_not(self):
         for ans, rx, msg in self._ans_match(WIKI_EXAMPLES_NOT):
             self.assertNotEqual(ans, rx, msg=msg)
 
-    def test_compat_rx(self):
+    def test_get_rx(self):
         for ans, rx, msg in self._ans_match(WIKI_EXAMPLES_RX):
             self.assertRegexpMatches(ans, rx, msg=msg)
 
-    def test_compat_not_rx(self):
+    def test_get_not_rx(self):
         for ans, rx, msg in self._ans_match(WIKI_EXAMPLES_NOT_RX):
             self.assertNotRegexpMatches(ans, rx, msg=msg)
 
@@ -108,7 +106,7 @@ class TestResolvers(unittest.TestCase):
         self.assertIs(first_paren(txt_none), None)
 
     def test_error_resolver(self):
-        err = self.kb.get('Bill Clinton', 'death-date')
+        err = self.kb.get('wikipedia-president', 'Bill Clinton', 'death-date')
         err = self.kb.get('wikipedia-person', 'Barack Obama', 'death-date')
         self.assertEqual(str(err),
                       '(((error attribute-value-not-found :reply '

--- a/wikipediabase/knowledgebase.py
+++ b/wikipediabase/knowledgebase.py
@@ -39,38 +39,23 @@ class KnowledgeBase(Provider):
         key = lambda a: len(' '.join(get_article(a).paragraphs()))
         return enchant(None, sorted(args, reverse=True, key=key))
 
-    @provide()
-    def get(self, v1, v2, v3=None):
+    @provide(name='get')
+    def get(self, cls, symbol, attr):
         """
-        Iterate of the provided attribute resolvers. The wikipedia class
-        in the question which would be v2 if all 3 args are present is
-        obsolete.
+        Gets the value of a symbol's attribute.
+
+        :param cls: Wikipedia class of the symbol
+        :param symbol: the Wikipedia article
+        :param attr: the attribute to get
+        :returns: the attribute's value or an error, enchanted
         """
-
-        if v3 is not None:
-            article, attr = v2, v3
-        else:
-            article, attr = v1, v2
-
-        ret = self._get(article, attr, compat=bool(v3))
-
-        # It probably is enchated but give it a chance.
-        return enchant(None, ret)
-
-    def _get(self, article, attr, compat):
-        """
-        In compatibility mode _get returns a tuple of the resolver gives
-        to the answer (for now 'code' or 'html') and the actual
-        answer.
-        """
-
-        # Attribute is wrapped into a dict just until we retrieve the
-        # keys.
         for ar in self.resolvers:
-            res = ar.resolve(article, attr)
-            # Errors enchantments should get returned.
+            res = ar.resolve(symbol, attr, cls=cls)
             if res is not None:
-                return res
+                break
+
+        # probably already enchanted, but try anyway
+        return enchant(None, res)
 
     @provide(name="get-classes")
     def get_classes(self, symbol):

--- a/wikipediabase/resolvers/base.py
+++ b/wikipediabase/resolvers/base.py
@@ -19,17 +19,17 @@ class BaseResolver(Provider):
 
         self._tag = None
 
-    def resolve(self, article, attribute, **kw):
+    def resolve(self, symbol, attr, **kw):
         """
 
         Use your resources to resolve. Use provided methods if available
         or return None.
         """
-        if isinstance(attribute, Enchanted):
-            attr = attribute.val
+        if isinstance(attr, Enchanted):
+            attr = attr.val
         else:
-            attr = attribute
+            attr = attr
 
         attr = attr.lower()
         if attr in self._resources:
-            return self._resources[attr](article, attribute)
+            return self._resources[attr](symbol, attr)

--- a/wikipediabase/resolvers/base.py
+++ b/wikipediabase/resolvers/base.py
@@ -8,7 +8,7 @@ class BaseResolver(Provider):
 
     priority = 1
 
-    def __init__(self, fetcher=None, compat=True, *args, **kwargs):
+    def __init__(self, fetcher=None, *args, **kwargs):
         """
         Provide a way to fetch articles. If no fetcher is provider
         fallback to BaseFetcher.
@@ -16,7 +16,6 @@ class BaseResolver(Provider):
 
         super(BaseResolver, self).__init__(*args, **kwargs)
         self.fetcher = fetcher or Fetcher()
-        self.compat = compat
 
         self._tag = None
 

--- a/wikipediabase/resolvers/error.py
+++ b/wikipediabase/resolvers/error.py
@@ -14,12 +14,12 @@ class ErrorResolver(BaseResolver):
         return enchant('error', {'symbol': sym or 'attribute-value-not-found',
                                  'kw': {'reply': repl or 'No such attribute'}})
 
-    def resolve(self, article, attribute):
+    def resolve(self, article, attribute, cls=None):
         kb = get_knowledgebase()
 
         if 'wikipedia-person' in kb.get_classes(article) and \
            attribute.lower() == 'death-date' and \
-           kb.get(article, 'birth-date'):
+           kb.get(cls, article, 'birth-date'):
             return self._err("Currently alive")
 
         return self._err("Unknown")

--- a/wikipediabase/resolvers/error.py
+++ b/wikipediabase/resolvers/error.py
@@ -14,12 +14,12 @@ class ErrorResolver(BaseResolver):
         return enchant('error', {'symbol': sym or 'attribute-value-not-found',
                                  'kw': {'reply': repl or 'No such attribute'}})
 
-    def resolve(self, article, attribute, cls=None):
+    def resolve(self, symbol, attr, cls=None):
         kb = get_knowledgebase()
 
-        if 'wikipedia-person' in kb.get_classes(article) and \
-           attribute.lower() == 'death-date' and \
-           kb.get(cls, article, 'birth-date'):
+        if 'wikipedia-person' in kb.get_classes(symbol) and \
+           attr.lower() == 'death-date' and \
+           kb.get(cls, symbol, 'birth-date'):
             return self._err("Currently alive")
 
         return self._err("Unknown")

--- a/wikipediabase/resolvers/infobox.py
+++ b/wikipediabase/resolvers/infobox.py
@@ -22,21 +22,21 @@ class InfoboxResolver(BaseResolver):
         self.fetcher = kwargs.get('fetcher', WIKIBASE_FETCHER)
         self._tag = "html"
 
-    def resolve(self, article, attribute, cls=None):
+    def resolve(self, symbol, attr, cls=None):
         """
         Return the value of the attribute for the article.
         """
 
-        if "\n" in article:
+        if "\n" in symbol:
             # There are no newlines in article titles
             return None
 
-        if isinstance(attribute, Enchanted):
-            key, attr = attribute.tag, attribute.val
+        if isinstance(attr, Enchanted):
+            key, attr = attr.tag, attr.val
         else:
-            key, attr = None, attribute
+            key, attr = None, attr
 
-        ibox = get_infobox(article, self.fetcher)
+        ibox = get_infobox(symbol, self.fetcher)
 
         if ibox:
             ret = ibox.get(attr)
@@ -48,4 +48,4 @@ class InfoboxResolver(BaseResolver):
             self.log().warning("Could not find infobox attribute '%s'" % attr)
         else:
             self.log().warning("Could not find infobox for article '%s'"
-                               % article)
+                               % symbol)

--- a/wikipediabase/resolvers/infobox.py
+++ b/wikipediabase/resolvers/infobox.py
@@ -22,13 +22,11 @@ class InfoboxResolver(BaseResolver):
         self.fetcher = kwargs.get('fetcher', WIKIBASE_FETCHER)
         self._tag = "html"
 
-    def resolve(self, article, attribute, **kw):
+    def resolve(self, article, attribute, cls=None):
         """
         Return the value of the attribute for the article.
         """
 
-        self.log().info("Using infobox resolver in %s mode" %
-                        "compatibility" if self.compat else "classic")
         if "\n" in article:
             # There are no newlines in article titles
             return None
@@ -44,12 +42,10 @@ class InfoboxResolver(BaseResolver):
             ret = ibox.get(attr)
             if ret:
                 self.log().info("Found infobox attribute '%s'" % attr)
-                assert(isinstance(ret, unicode)) # TODO : remove for production
-                return enchant(key, ret, result_from=attr,
-                               log=self.log())
+                assert(isinstance(ret, unicode))  # TODO: remove for production
+                return enchant(key, ret, result_from=attr, log=self.log())
 
-            self.log().warning("Could not find infobox attribute '%s'"
-                               % attr)
+            self.log().warning("Could not find infobox attribute '%s'" % attr)
         else:
             self.log().warning("Could not find infobox for article '%s'"
                                % article)

--- a/wikipediabase/resolvers/paragraph.py
+++ b/wikipediabase/resolvers/paragraph.py
@@ -46,23 +46,23 @@ class LifespanParagraphResolver(BaseResolver):
 
         super(LifespanParagraphResolver, self).__init__(*args, **kwargs)
 
-    def resolve(self, article, attribute, **kw):
+    def resolve(self, symbol, attr, **kwargs):
         """
         Resolve birth and death dates based on the first paragraph.
         """
 
-        if isinstance(attribute, Enchanted):
-            attr = attribute.val.lower()
+        if isinstance(attr, Enchanted):
+            attr = attr.val.lower()
         else:
-            attr = attribute.lower()
+            attr = attr.lower()
 
         if attr == 'short-article':
-            return get_article(article).first_paragraph()
+            return get_article(symbol).first_paragraph()
 
         if attr not in ("birth-date", "death-date"):
             return None
 
-        art = get_article(article)
+        art = get_article(symbol)
 
         # The frst paragraph
         text = art.paragraphs()[0]


### PR DESCRIPTION
Compatibility and classic modes are gone -- WikipediaBase always returns answers with a typecode (this used to be 'compatibility mode'). Fixes #50.

Refactored resolvers to adhere to WikipediaBase naming conventions. The naming convention is for Wikipedia articles to be called `symbol` (except when dealing with an instance of the `Article` class). Infobox attributes should be called `attr` and Wikipedia classes `cls`.

Changed the `get` knowledgebase method now always require a wikipedia class.