### PR TITLE
Comment out tests that fail spuriously

### DIFF
--- a/tests/examples.py
+++ b/tests/examples.py
@@ -304,17 +304,19 @@ WIKI_EXAMPLES_RX = [
     # {{convert|..}} template
     ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "LENGTH"))',
      r'360.*km.*220.*mi'),
-    ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "WIDTH"))',
-     r'180.*km.*110.*mi'),
-    ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "AREA"))',
-     r'39.?000.*km.*2.*15.?000.*sq.*mi'),
-    ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "DEPTH"))',
-     r'7.*met.*23.*ft'),
-    ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "MAX-DEPTH"))',
-     r'14.*m.*46.*ft'),
-
-    ('(get "wikipedia-sea" "Sea of Azov" (:CODE "VOLUME"))',
-     r'290.*km.*3'),
+    # TODO : debug why the examples below fail spuriously and uncomment them
+    # the tests occasionally fail due to a suspected race condition with lxml
+    # See issue #35 for more context
+    # ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "WIDTH"))',
+    #  r'180.*km.*110.*mi'),
+    # ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "AREA"))',
+    #  r'39.?000.*km.*2.*15.?000.*sq.*mi'),
+    # ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "DEPTH"))',
+    #  r'7.*met.*23.*ft'),
+    # ('(get "wikipedia-ocean" "Sea of Azov" (:CODE "MAX-DEPTH"))',
+    #  r'14.*m.*46.*ft'),
+    #('(get "wikipedia-sea" "Sea of Azov" (:CODE "VOLUME"))',
+    # r'290.*km.*3'),
 
     ('(get "wikipedia-military-conflict" "American Civil War" (:code "RESULT"))',
      re.compile(r'Union victory.*Slavery abolished.*Territorial integrity.*Lincoln assassinated.*Reconstruction', re.DOTALL)),


### PR DESCRIPTION
Commented out tests that fail spuriously as a temporary measure -- see #35 and #48 for more context.

These spurious tests have been causing builds to fail, to the point where we don't know if a Travis failure means that a change actually broke functionality. To ensure that we can keep making progress, I've commented out 5/6 "Sea of Azov" examples.

#35 and #48 remain open and need investigation.