### PR TITLE
Fix bugs in enchantments and add more tests

### DIFF
--- a/tests/examples.py
+++ b/tests/examples.py
@@ -53,12 +53,12 @@ WIKI_EXAMPLES = [
      '((:yyyymmdd 19610804))'),
     ('(get "wikipedia-person" "Barack Obama" "DEATH-DATE")',
      # 'nil'),
-     '((error attribute-value-not-found :reply "Currently alive"))'),
+     '((:error attribute-value-not-found :reply "Currently alive"))'),
     ('(get "wikipedia-person" "Jamie Glover" "BIRTH-DATE")',
      '((:yyyymmdd 19690710))'),
     ('(get "wikipedia-person" "Jamie Glover" "DEATH-DATE")',
      #  'nil'),
-     '((error attribute-value-not-found :reply "Currently alive"))'),
+     '((:error attribute-value-not-found :reply "Currently alive"))'),
     ('(get "wikipedia-person" "John Lennon" "BIRTH-DATE")',
      '((:yyyymmdd 19401009))'),
     ('(get "wikipedia-person" "John Lennon" "DEATH-DATE")',
@@ -84,7 +84,7 @@ WIKI_EXAMPLES = [
     # is not correct either but it is the
     # only date provided
     # ('(get "wikipedia-person" "William Shakesppeare" "BIRTH-DATE")',
-    # '#f'), XXX: you cant get both right...
+    # 'nil'), XXX: you cant get both right...
     ('(get "wikipedia-person" "Violet Markham" "BIRTH-DATE")',
      '((:yyyymmdd 18720000))'),
     ('(get "wikipedia-person" "Violet Markham" "DEATH-DATE")',
@@ -166,26 +166,26 @@ DEGENERATE_EXAMPLES = [
      '((:calculated :feminine))'),
 
     ('(get "wikibase-term" "Bill Clinton" (:calculated "PROPER"))',
-     '((:calculated #t))'),
+     '((:calculated t))'),
     ('(get "wikibase-term" "North American Free Trade Agreement" (:calculated "PROPER"))',
-     '((:calculated #t))'),
+     '((:calculated t))'),
     ('(get "wikibase-term" "Purchasing power parity" (:calculated "PROPER"))',
-     '((:calculated #f))'),
+     '((:calculated nil))'),
     ('(get "wikipedia-musical-artist" "Lamb of God (band)" "PROPER")',
-     '((:calculated #t))'),
+     '((:calculated t))'),
     ('(get "wikibase-term" "Board game" "PROPER")',
-     '((:calculated #f))'),
+     '((:calculated nil))'),
 
     # This means plural or singular I guess
     ('(get "wikibase-term" "Bill Clinton" (:calculated "NUMBER"))',
-     '((:calculated #f))'),
+     '((:calculated nil))'),
     ('(get "wikibase-term" "The Beatles" (:calculated "NUMBER"))',
-     '((:calculated #t))'),
+     '((:calculated t))'),
 
     ('(get "wikipedia-person" "Barack Obama" "DEATH-DATE")',
-     '((error attribute-value-not-found :reply "Currently alive"))'),
+     '((:error attribute-value-not-found :reply "Currently alive"))'),
     ('(get "wikipedia-person" "Barack Obama" "DEATH-PLACE")',
-     '((error attribute-value-not-found :reply "Currently alive"))'),
+     '((:error attribute-value-not-found :reply "Currently alive"))'),
 ]
 
 WIKI_EXAMPLES_NOT = [

--- a/tests/test_enchantments.py
+++ b/tests/test_enchantments.py
@@ -21,11 +21,11 @@ class TestEnchantments(unittest.TestCase):
     def test_string(self):
         self.assertEqual(enchant("foo"), '"foo"')
 
-    def test_unicode_string(self):
-        self.assertEqual(enchant(u"föø"), '"foo"')
-
     def test_string_escaped(self):
-        self.assertEqual(enchant('foo "bar"'), '"foo \\"bar\\""')
+        self.assertEqual(enchant('foo \\ "bar"'), '"foo \\ \\"bar\\""')
+
+    def test_unicode_string(self):
+        self.assertEqual(enchant(u"föø ” "), '"foo \\" "')
 
     def test_string_with_typecode(self):
         self.assertEqual(enchant("bar", typecode="html"), '(:html "bar")')
@@ -57,18 +57,18 @@ class TestEnchantments(unittest.TestCase):
         self.assertEqual(ed, '(:yyyymmdd 20100000)')
 
     def test_date_with_range(self):
-        # 2010 is in the given range, thus it wil precede 8,8,1991
+        # 2010 is in the given range, thus it will precede 8,8,1991
         ed = enchant("2010 8.9.1991 - 2012 on August the 8th 1991",
                      typecode="yyyymmdd")
         self.assertEqual(ed, '(:yyyymmdd 20100000)')
 
     def test_bool(self):
-        self.assertEqual(enchant(True), '#t')
-        self.assertEqual(enchant(False), '#f')
+        self.assertEqual(enchant(True), 't')
+        self.assertEqual(enchant(False), 'nil')
 
     def test_bool_with_typecode(self):
         self.assertEqual(enchant(False, typecode='calculated'),
-                         '(:calculated #f)')
+                         '(:calculated nil)')
 
     def test_keyword(self):
         self.assertEqual(enchant(':feminine'), ":feminine")
@@ -82,20 +82,24 @@ class TestEnchantments(unittest.TestCase):
 
     def test_dict(self):
         self.assertEqual(enchant({'a': 1, 'b': "foo"}),
-                         '(:b "foo" :a "1")')
+                         '(:a 1 :b "foo")')
 
     def test_dict_with_escaped_string(self):
         self.assertEqual(enchant({'a': 1, 'b': '"foo"'}),
-                         '(:b "\\"foo\\"" :a "1")')
+                         '(:a 1 :b "\\"foo\\"")')
+
+    def test_dict_with_list(self):
+        self.assertEqual(enchant({'a': 1, 'b': ['foo', 'bar']}),
+                         '(:a 1 :b ("foo" "bar"))')
 
     def test_error(self):
         err = enchant({'symbol': 'sym', 'kw': dict(a=1, b=2, c='ha')},
                       typecode='error')
-        self.assertEqual(err, '(error sym :a "1" :c "ha" :b "2")')
+        self.assertEqual(err, '(:error sym :a 1 :b 2 :c "ha")')
 
     def test_error_from_exception(self):
         err = enchant(ValueError('Wrong thing'))
-        self.assertEqual(err, '(error ValueError :reply "Wrong thing")')
+        self.assertEqual(err, '(:error ValueError :message "Wrong thing")')
 
     def test_none(self):
         self.assertEqual(enchant(None), 'nil')

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -109,8 +109,8 @@ class TestResolvers(unittest.TestCase):
         err = self.kb.get('wikipedia-president', 'Bill Clinton', 'death-date')
         err = self.kb.get('wikibase-person', 'Barack Obama', 'death-date')
         self.assertEqual(str(err),
-                      '((error attribute-value-not-found :reply '
-                      '"Currently alive"))')
+                         '((:error attribute-value-not-found :reply '
+                         '"Currently alive"))')
 
     def _ans_match(self, lst, just=None):
         """

--- a/wikipediabase/enchantments.py
+++ b/wikipediabase/enchantments.py
@@ -135,7 +135,7 @@ class EnchantedString(Enchanted):
     def val_str(self):
         v = re.sub(r"\[\d*\]", "", self.val)  # remove references, e.g. [1]
         v = re.sub(r"[[\]]", "", v)  # remove wikimarkup links, e.g. [[Ruby]]
-        v = output(unicode(v)) # unidecode
+        v = output(unicode(v)) # remove unicode characters
         v = v.replace('"', '\\"')  # escape double quotes
         v = u'"{0}"'.format(v)
         return v


### PR DESCRIPTION
More improvements to enchantments after discussing with @sfelshin.

Instead of using Guile's #t/#f, use Common Lisp conventions: 't' for True and 'nil' for False.

Use :error for the error typecode.

Rename EnchantedStringDict to EnchantedDict, and allow it to have values other than strings.

Fix bugs in EnchantedString where unicode curly double quotes weren't correctly escaped.