### PR TITLE
Rename enchantments to lispify and Enchanted to LispType

### DIFF
--- a/tests/test_knowledgebase.py
+++ b/tests/test_knowledgebase.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from wikipediabase.knowledgebase import KnowledgeBase
 from wikipediabase.provider import Acquirer
-from wikipediabase.enchantments import EnchantedList
+from wikipediabase.lispify import LispList
 
 CLINTON_ATTRS = ('(:code "NAME")', '(:code "IMAGE")', '(:code "ORDER")', '(:code "OFFICE")', '(:code "VICEPRESIDENT" :rendered "Vice President")', '(:code "TERM-START")', '(:code "TERM-END")', '(:code "PREDECESSOR")', '(:code "SUCCESSOR")', '(:code "ORDER1")', '(:code "OFFICE1")', '(:code "LIEUTENANT1")', '(:code "TERM-START1")', '(:code "TERM-END1")', '(:code "PREDECESSOR1")', '(:code "SUCCESSOR1")', '(:code "LIEUTENANT2")', '(:code "TERM-START2")', '(:code "TERM-END2")', '(:code "PREDECESSOR2")', '(:code "SUCCESSOR2")', '(:code "ORDER3")', '(:code "OFFICE3")', '(:code "GOVERNOR3")', '(:code "TERM-START3")', '(:code "TERM-END3")', '(:code "PREDECESSOR3")', '(:code "SUCCESSOR3")', '(:code "BIRTH-NAME" :rendered "Born")', '(:code "BIRTH-DATE" :rendered "Born")', '(:code "BIRTH-PLACE" :rendered "Born")', '(:code "PARTY" :rendered "Political party")', '(:code "PROFESSION" :rendered "Profession")', '(:code "PARENTS" :rendered "Parents")', '(:code "RELATIONS" :rendered "Relations")', '(:code "SPOUSE" :rendered "Spouse(s)', ')', '(:code "CHILDREN" :rendered "Children")', '(:code "ALMA-MATER" :rendered "Alma mater")', '(:code "RELIGION" :rendered "Religion")', '(:code "SIGNATURE")', '(:code "SIGNATURE-ALT")')
 
@@ -59,7 +59,7 @@ class TestKnowledgebase(unittest.TestCase):
 
     def test_sort_symbols(self):
         ench = self.fe.resources()['sort-symbols']("Mary Shakespeare", "Batman")
-        self.assertIs(type(ench), EnchantedList)
+        self.assertIs(type(ench), LispList)
         self.assertEqual(ench.val, ["Batman", "Mary Shakespeare"])
 
     def test_synonyms(self):

--- a/tests/test_lispify.py
+++ b/tests/test_lispify.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 
 """
-test_enchantments
+test_lispify
 ----------------------------------
 
-Tests for `enchantments` module.
+Tests for `lispify` module.
 """
 
 try:
@@ -13,106 +13,106 @@ try:
 except ImportError:
     import unittest
 
-from wikipediabase.enchantments import enchant
+from wikipediabase.lispify import lispify
 
 
-class TestEnchantments(unittest.TestCase):
+class TestLispify(unittest.TestCase):
 
     def test_string(self):
-        self.assertEqual(enchant("foo"), '"foo"')
+        self.assertEqual(lispify("foo"), '"foo"')
 
     def test_string_escaped(self):
-        self.assertEqual(enchant('foo \\ "bar"'), '"foo \\ \\"bar\\""')
+        self.assertEqual(lispify('foo \\ "bar"'), '"foo \\ \\"bar\\""')
 
     def test_unicode_string(self):
-        self.assertEqual(enchant(u"föø ” "), '"foo \\" "')
+        self.assertEqual(lispify(u"föø ” "), '"foo \\" "')
 
     def test_string_with_typecode(self):
-        self.assertEqual(enchant("bar", typecode="html"), '(:html "bar")')
+        self.assertEqual(lispify("bar", typecode="html"), '(:html "bar")')
 
     def test_list(self):
         l = ['wikipedia-class1', 'wikipedia-class2']
-        self.assertEqual(enchant(l), '("wikipedia-class1" "wikipedia-class2")')
+        self.assertEqual(lispify(l), '("wikipedia-class1" "wikipedia-class2")')
 
     def test_list_with_typecode(self):
         l = [44, 35]
-        self.assertEqual(enchant(l, typecode='coordinates'),
+        self.assertEqual(lispify(l, typecode='coordinates'),
                          '(:coordinates 44 35)')
 
     def test_nested_list(self):
         l = [[0, 'foo'], [1, '"bar"']]
-        self.assertEqual(enchant(l), '((0 "foo") (1 "\\"bar\\""))')
+        self.assertEqual(lispify(l), '((0 "foo") (1 "\\"bar\\""))')
 
     def test_double_nested_list(self):
         l = [[0, ['v0', 'foo']], [1, ['v1', 'bar']]]
-        self.assertEqual(enchant(l), '((0 ("v0" "foo")) (1 ("v1" "bar")))')
+        self.assertEqual(lispify(l), '((0 ("v0" "foo")) (1 ("v1" "bar")))')
 
     def test_date_simple(self):
-        ed = enchant("coming on August the 8th", typecode="yyyymmdd")
+        ed = lispify("coming on August the 8th", typecode="yyyymmdd")
         self.assertEqual(ed, '(:yyyymmdd 00000808)')
 
     def test_date_multiple_voting(self):
-        ed = enchant("2010 8.8.1991 on August the 8th 1991",
+        ed = lispify("2010 8.8.1991 on August the 8th 1991",
                      typecode="yyyymmdd")
         self.assertEqual(ed, '(:yyyymmdd 20100000)')
 
     def test_date_with_range(self):
         # 2010 is in the given range, thus it will precede 8,8,1991
-        ed = enchant("2010 8.9.1991 - 2012 on August the 8th 1991",
+        ed = lispify("2010 8.9.1991 - 2012 on August the 8th 1991",
                      typecode="yyyymmdd")
         self.assertEqual(ed, '(:yyyymmdd 20100000)')
 
     def test_bool(self):
-        self.assertEqual(enchant(True), 't')
-        self.assertEqual(enchant(False), 'nil')
+        self.assertEqual(lispify(True), 't')
+        self.assertEqual(lispify(False), 'nil')
 
     def test_bool_with_typecode(self):
-        self.assertEqual(enchant(False, typecode='calculated'),
+        self.assertEqual(lispify(False, typecode='calculated'),
                          '(:calculated nil)')
 
     def test_keyword(self):
-        self.assertEqual(enchant(':feminine'), ":feminine")
+        self.assertEqual(lispify(':feminine'), ":feminine")
 
     def test_string_not_keyword(self):
-        self.assertEqual(enchant(':not a keyword'), '":not a keyword"')
+        self.assertEqual(lispify(':not a keyword'), '":not a keyword"')
 
     def test_keyword_with_typecode(self):
-        self.assertEqual(enchant(':feminine', typecode='calculated'),
+        self.assertEqual(lispify(':feminine', typecode='calculated'),
                          '(:calculated :feminine)')
 
     def test_dict(self):
-        self.assertEqual(enchant({'a': 1, 'b': "foo"}),
+        self.assertEqual(lispify({'a': 1, 'b': "foo"}),
                          '(:a 1 :b "foo")')
 
     def test_dict_with_escaped_string(self):
-        self.assertEqual(enchant({'a': 1, 'b': '"foo"'}),
+        self.assertEqual(lispify({'a': 1, 'b': '"foo"'}),
                          '(:a 1 :b "\\"foo\\"")')
 
     def test_dict_with_list(self):
-        self.assertEqual(enchant({'a': 1, 'b': ['foo', 'bar']}),
+        self.assertEqual(lispify({'a': 1, 'b': ['foo', 'bar']}),
                          '(:a 1 :b ("foo" "bar"))')
 
     def test_error(self):
-        err = enchant({'symbol': 'sym', 'kw': dict(a=1, b=2, c='ha')},
+        err = lispify({'symbol': 'sym', 'kw': dict(a=1, b=2, c='ha')},
                       typecode='error')
         self.assertEqual(err, '(:error sym :a 1 :b 2 :c "ha")')
 
     def test_error_from_exception(self):
-        err = enchant(ValueError('Wrong thing'))
+        err = lispify(ValueError('Wrong thing'))
         self.assertEqual(err, '(:error ValueError :message "Wrong thing")')
 
     def test_none(self):
-        self.assertEqual(enchant(None), 'nil')
+        self.assertEqual(lispify(None), 'nil')
 
     def test_none_with_typecode(self):
-        self.assertEqual(enchant(None, typecode='calculated'),
+        self.assertEqual(lispify(None, typecode='calculated'),
                          '(:calculated nil)')
 
     def test_number(self):
-        self.assertEqual(enchant(5), '5')
+        self.assertEqual(lispify(5), '5')
 
     def test_number_with_typecode(self):
-        self.assertEqual(enchant(5, typecode='calculated'),
+        self.assertEqual(lispify(5, typecode='calculated'),
                          '(:calculated 5)')
 
 if __name__ == '__main__':

--- a/wikipediabase/frontend.py
+++ b/wikipediabase/frontend.py
@@ -4,7 +4,7 @@
 from edn_format import loads, Keyword, Symbol
 
 from wikipediabase.telnet import TelnetServer
-from wikipediabase.enchantments import enchant
+from wikipediabase.lispify import lispify
 from wikipediabase.provider import Acquirer, provide
 from wikipediabase.util import get_knowledgebase
 
@@ -26,11 +26,11 @@ class Frontend(Acquirer):
 
     @provide(name='commands')
     def commands(self):
-        return enchant([i for i, _ in self.resources().iteritems()])
+        return lispify([i for i, _ in self.resources().iteritems()])
 
     def get_callable(self, symbol):
         """
-        Given a function name return the callable. Keywods should enchant
+        Given a function name return the callable. Keywords should lispify
         the arguments.
         """
 
@@ -38,7 +38,7 @@ class Frontend(Acquirer):
             return self.resources()[symbol._name]
 
         if isinstance(symbol, Keyword):
-            return lambda *args: enchant(*args, typecode=symbol._name)
+            return lambda *args: lispify(*args, typecode=symbol._name)
 
         raise TypeError("Could not resolve function %s (type %s)."
                         % (symbol, str(type(symbol))))
@@ -70,7 +70,7 @@ class TelnetFrontend(Frontend):
             if isinstance(e, SystemExit):
                 raise e
 
-            return unicode(enchant(e, typecode='error')) + u'\n'
+            return unicode(lispify(e, typecode='error')) + u'\n'
 
     def __init__(self, *args, **kwargs):
         super(TelnetFrontend, self).__init__(*args, **kwargs)

--- a/wikipediabase/knowledgebase.py
+++ b/wikipediabase/knowledgebase.py
@@ -4,7 +4,7 @@ from itertools import chain
 
 from wikipediabase.provider import Provider, provide
 from wikipediabase.fetcher import WIKIBASE_FETCHER
-from wikipediabase.enchantments import enchant
+from wikipediabase.lispify import lispify
 from wikipediabase.resolvers import WIKIBASE_RESOLVERS
 from wikipediabase.classifiers import WIKIBASE_CLASSIFIERS
 from wikipediabase.synonym_inducers import WIKIBASE_INDUCERS
@@ -37,7 +37,7 @@ class KnowledgeBase(Provider):
     @provide(name='sort-symbols')
     def sort_symbols(self, *args):
         key = lambda a: len(' '.join(get_article(a).paragraphs()))
-        return enchant(sorted(args, reverse=True, key=key))
+        return lispify(sorted(args, reverse=True, key=key))
 
     @provide(name='get')
     def get(self, cls, symbol, attr):
@@ -47,39 +47,39 @@ class KnowledgeBase(Provider):
         :param cls: Wikipedia class of the symbol
         :param symbol: the Wikipedia article
         :param attr: the attribute to get
-        :returns: the attribute's value or an error, enchanted
+        :returns: the attribute's value or an error, lispified
         """
         for ar in self.resolvers:
             res = ar.resolve(symbol, attr, cls=cls)
             if res is not None:
                 break
 
-        return enchant([res])
+        return lispify([res])
 
     @provide(name="get-classes")
     def get_classes(self, symbol):
         it = chain.from_iterable((c.classify(symbol)
                                   for c in self.classifiers))
-        return enchant(list(it))
+        return lispify(list(it))
 
     @provide(name="get-types")
     def get_types(self, symbol):
         types = get_article(symbol).types()
-        return enchant(types)
+        return lispify(types)
 
     @provide(name="get-categories")
     def get_categories(self, symbol):
         categories = get_article(symbol).categories()
-        return enchant(categories)
+        return lispify(categories)
 
     @provide(name="get-attributes")
     def get_attributes(self, wb_class, symbol=None):
         if symbol is not None:
-            return enchant(self._get_attrs(symbol))
+            return lispify(self._get_attrs(symbol))
 
         # We don't really need wb_class, symbol is enough so it might
         # not be provided
-        return enchant(self._get_attrs(wb_class))
+        return lispify(self._get_attrs(wb_class))
 
     def synonyms(self, symbol):
         synonyms = set()
@@ -87,7 +87,7 @@ class KnowledgeBase(Provider):
         for si in self.synonym_inducers:
             synonyms.update(si.induce(symbol))
 
-        return enchant(synonyms)
+        return lispify(synonyms)
 
     def _get_attrs(self, symbol):
         """
@@ -99,7 +99,7 @@ class KnowledgeBase(Provider):
         ret = []
         for k, v in ibox.markup_parsed_iter():
             rendered = ibox.rendered_attributes().get(k.replace('-', '_'))
-            tmp = enchant(dict(code=k.upper(),
+            tmp = lispify(dict(code=k.upper(),
                                rendered=rendered))
 
             ret.append(tmp)

--- a/wikipediabase/resolvers/base.py
+++ b/wikipediabase/resolvers/base.py
@@ -1,8 +1,9 @@
-from wikipediabase.enchantments import Enchanted
+from wikipediabase.lispify import LispType
 from wikipediabase.fetcher import Fetcher
 from wikipediabase.provider import Provider
 
 MIN_PRIORITY = 0
+
 
 class BaseResolver(Provider):
 
@@ -25,7 +26,7 @@ class BaseResolver(Provider):
         Use your resources to resolve. Use provided methods if available
         or return None.
         """
-        if isinstance(attr, Enchanted):
+        if isinstance(attr, LispType):
             attr = attr.val
         else:
             attr = attr

--- a/wikipediabase/resolvers/error.py
+++ b/wikipediabase/resolvers/error.py
@@ -1,6 +1,6 @@
 from wikipediabase.resolvers.base import MIN_PRIORITY, BaseResolver
 from wikipediabase.util import get_knowledgebase
-from wikipediabase.enchantments import enchant
+from wikipediabase.lispify import lispify
 
 
 class ErrorResolver(BaseResolver):
@@ -13,7 +13,7 @@ class ErrorResolver(BaseResolver):
 
     @staticmethod
     def _err(repl=None, sym=None):
-        return enchant({'symbol': sym or 'attribute-value-not-found',
+        return lispify({'symbol': sym or 'attribute-value-not-found',
                         'kw': {'reply': repl or 'No such attribute'}},
                        typecode='error')
 

--- a/wikipediabase/resolvers/infobox.py
+++ b/wikipediabase/resolvers/infobox.py
@@ -1,6 +1,6 @@
 from wikipediabase.resolvers.base import BaseResolver
 from wikipediabase.util import get_infobox
-from wikipediabase.enchantments import enchant, Enchanted
+from wikipediabase.lispify import lispify, LispType
 from wikipediabase.fetcher import WIKIBASE_FETCHER
 
 
@@ -31,7 +31,7 @@ class InfoboxResolver(BaseResolver):
             # There are no newlines in article titles
             return None
 
-        if isinstance(attr, Enchanted):
+        if isinstance(attr, LispType):
             typecode, attr = attr.typecode, attr.val
         else:
             typecode, attr = self._typecode, attr
@@ -44,7 +44,7 @@ class InfoboxResolver(BaseResolver):
                 self.log().info("Found infobox attribute '%s'" % attr)
                 assert(isinstance(result, unicode)) # TODO: remove for production
 
-                return enchant(result, typecode=typecode, infobox_attr=attr)
+                return lispify(result, typecode=typecode, infobox_attr=attr)
 
             self.log().warning("Could not find infobox attribute '%s'" % attr)
         else:

--- a/wikipediabase/resolvers/paragraph.py
+++ b/wikipediabase/resolvers/paragraph.py
@@ -2,7 +2,7 @@ import overlay_parse
 
 from wikipediabase.resolvers.base import BaseResolver
 from wikipediabase.util import get_article
-from wikipediabase.enchantments import enchant, Enchanted
+from wikipediabase.lispify import lispify, LispType
 
 
 def iter_paren(text, delim=None):
@@ -51,7 +51,7 @@ class LifespanParagraphResolver(BaseResolver):
         Resolve birth and death dates based on the first paragraph.
         """
 
-        if isinstance(attr, Enchanted):
+        if isinstance(attr, LispType):
             attr = attr.val.lower()
         else:
             attr = attr.lower()
@@ -71,12 +71,12 @@ class LifespanParagraphResolver(BaseResolver):
 
             for ovl in overlay_parse.dates.just_ranges(paren):
                 if attr == 'birth-date':
-                    return enchant(ovl[0], typecode='yyyymmdd')
+                    return lispify(ovl[0], typecode='yyyymmdd')
                 elif attr == 'death-date':
-                    return enchant(ovl[1], typecode='yyyymmdd')
+                    return lispify(ovl[1], typecode='yyyymmdd')
 
             # If there is just one date and we need a birth date, get
             # that.
             if attr == 'birth-date':
                 for ovl in overlay_parse.dates.just_dates(paren):
-                    return enchant(ovl, typecode='yyyymmdd')
+                    return lispify(ovl, typecode='yyyymmdd')

--- a/wikipediabase/resolvers/static.py
+++ b/wikipediabase/resolvers/static.py
@@ -4,7 +4,7 @@ import re
 
 from wikipediabase.provider import provide
 from wikipediabase.resolvers.base import BaseResolver
-from wikipediabase.enchantments import enchant
+from wikipediabase.lispify import lispify
 from wikipediabase.util import get_infobox, get_article, totext, markup_unlink
 
 
@@ -31,10 +31,10 @@ class StaticResolver(BaseResolver):
         cls = PersonClassifier().classify(article)
 
         if 'wikibase-male' in cls:
-            return enchant(':masculine', typecode='calculated')
+            return lispify(':masculine', typecode='calculated')
 
         if 'wikibase-female' in cls:
-            return enchant(':feminine', typecode='calculated')
+            return lispify(':feminine', typecode='calculated')
 
     @staticmethod
     def _dton(s):
@@ -70,11 +70,11 @@ class StaticResolver(BaseResolver):
         nlat = self._dton(totext(lat))
         nlon = self._dton(totext(lon))
 
-        return enchant([nlat, nlon], typecode='coordinates')
+        return lispify([nlat, nlon], typecode='coordinates')
 
     @provide(name="image-data")
     def image(self, article, attribute):
-        # Make sure we are not getting back the enchanted.
+        # Make sure we are not getting back a LispType.
 
         ibx = get_infobox(article)
         img = ibx.get('image')
@@ -91,7 +91,7 @@ class StaticResolver(BaseResolver):
             fnam = fnam.split("{{!}}border")[0]
 
         cap = ibx.get('caption')
-        return enchant([0, fnam] + ([markup_unlink(cap)] if cap else []))
+        return lispify([0, fnam] + ([markup_unlink(cap)] if cap else []))
 
     @provide(name='url')
     def url(self, article, _):
@@ -102,7 +102,7 @@ class StaticResolver(BaseResolver):
         # Will also teake care of redirections.
         article = get_article(article)
         url = article.url()
-        return enchant(url, typecode='url')
+        return lispify(url, typecode='url')
 
     @provide(name='number')
     def number(self, article, _):
@@ -117,7 +117,7 @@ class StaticResolver(BaseResolver):
         yay = sum(map(txt.count, [' are ', ' were ', ' have ']))
 
         # inequality because there are many more nays
-        return enchant(yay > nay, typecode='calculated')
+        return lispify(yay > nay, typecode='calculated')
 
     @provide(name='proper')
     def proper(self, article, _):
@@ -132,4 +132,4 @@ class StaticResolver(BaseResolver):
         ret = (txt.count(a.lower()) - txt.count(". " + a.lower()) <
                txt.count(a))
 
-        return enchant(ret, typecode='calculated')
+        return lispify(ret, typecode='calculated')


### PR DESCRIPTION
Renamed enchantments module to lispify. Renamed `Enchanted` to `LispType`. Minor updates to comments.

Fixes #71 