### PR TITLE
Whitelist text formatting tags in :html responses

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+data/wikibase-term-*symbols filter=lfs diff=lfs merge=lfs -text
+data/wikibase-term-*synonyms filter=lfs diff=lfs merge=lfs -text

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script:
     - coverage run setup.py test
 after_success:
     - coveralls
+env:
+    - WIKIPEDIABASE_FORCE_LIVE=true

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Tests can then be run with:
 
     python setup.py test
 
+_Note: tests assume that you have set up the backend. To fetch from wikipedia.org instead of reading from the database, set the env variable `WIKIPEDIABASE_FORCE_LIVE=true`. This is strongly discouraged if you plan to use or contribute to WikipediaBase, as performance will be slow._
+
 ## API documentation
 
 Generate the documentation with:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 [![Build Status](https://travis-ci.org/infolab-csail/WikipediaBase.svg?branch=master)](https://travis-ci.org/infolab-csail/WikipediaBase)
 [![Stories in Ready](https://badge.waffle.io/infolab-csail/WikipediaBase.svg?label=ready&title=Ready)](http://waffle.io/infolab-csail/WikipediaBase)
-[![# of downloads](https://pypip.in/d/wikipediabase/badge.png)](https://crate.io/packages/wikipediabase?version=latest)
 [![Coverage Status](https://coveralls.io/repos/infolab-csail/WikipediaBase/badge.svg?branch=master&service=github)](https://coveralls.io/github/infolab-csail/WikipediaBase?branch=master)
 
 ## Overview
@@ -14,10 +13,14 @@ Wikipedia backend interface for
 [InfoLab's START](http://start.mit.edu). It answers s-expression
 queries via Telnet.
 
-## Usage
-Install `pip` and `gdbm` if not installed:
+## Documentation
 
-    apt-get install python-setuptools python-gdbm
+[API documentation](http://wikipediabase.rtfd.org)
+
+## Installing
+Install `pip` and `redis-server` if not installed:
+
+    apt-get install python-setuptools redis-server
 
 > Caution: Until wikipedibase is deployed on START installing it for non-testing purposes is not something one is supposed to do.
 
@@ -25,9 +28,31 @@ Install `wikipediabase`:
 
     python setup.py install
 
-## Documentation
+## Setting up the backend
 
-[API Documentation](http://wikipediabase.rtfd.org)
+1. Configure the backend. The scripts checks that Postgres and Redis are running, and creates the necessary tables.
+
+   ```
+   ./scripts/configure_db.py
+   ```
+
+   If Postgres throws `ERROR: new encoding (UTF8) is incompatible with the encoding of the template database (SQL_ASCII)`, follow [these](https://gist.github.com/ffmike/877447) instructions.
+
+1. Download the latest Wikipedia [dump](http://dumps.wikimedia.org/enwiki/).
+
+1. Create the backend. This step takes about 10 hours.
+
+   ```
+   bzcat /path/to/enwiki-YYYYMMDD-pages-articles.xml.bz2 | ./scripts/create_db.py
+   ```
+
+1. Generate symbols and synonyms (optional). This step takes about 40 hours.
+
+   ```
+   ./scripts/generate_symbols_and_synonyms.py
+   ```
+
+   Install [Git LFS](https://git-lfs.github.com/) and commit the changes to files in `data/`.
 
 ## Testing
 

--- a/data/wikibase-term-generated-synonyms
+++ b/data/wikibase-term-generated-synonyms
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4151c1f626936976e4be95e1c29d5f93d271decb45bea7434bc8d58d9108bc5
+size 563914871

--- a/data/wikibase-term-symbols
+++ b/data/wikibase-term-symbols
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5073dbb0e14ad5b82623a01372cf8f001f282393f9d291c3ea9e1d1c2a97b898
+size 97023360

--- a/scripts/generate_symbols_and_synonyms.py
+++ b/scripts/generate_symbols_and_synonyms.py
@@ -19,8 +19,8 @@ logging.basicConfig(filename='symbols.log', level=logging.DEBUG)
 logging.getLogger("peewee").setLevel(logging.WARNING)
 
 # TODO: change paths; pass in data_dir in sys.argv
-symbols_f = open('../data/wikibase-term-foo-symbols', 'w')
-synonyms_f = open('../data/wikibase-term-foo-generated-synonyms', 'w')
+symbols_f = open('../data/wikibase-term-symbols', 'w')
+synonyms_f = open('../data/wikibase-term-generated-synonyms', 'w')
 
 latest_symbols = LRUCache(100)
 

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -224,6 +224,10 @@ DEGENERATE_EXAMPLES = [
     # infobox defined outside the article, in its own template
     ('(get "wikipedia-military-conflict" "World War I" (:code "DATE"))',
      ('((:yyyymmdd 19140728))')),
+
+    # Ignore the sup tag. There is no way to represent it otherwise.
+    ('(get "wikipedia-sea" "Black Sea" (:code "AREA"))',
+     '((:html "436,402 km<sup>2</sup> (168,500 sq mi)"))')
 ]
 
 WIKI_EXAMPLES_NOT = [

--- a/tests/test_infobox.py
+++ b/tests/test_infobox.py
@@ -33,6 +33,30 @@ class TestInfobox(unittest.TestCase):
         ibox = get_rendered_infoboxes("AC/DC")[0]
         self.assertIn(("Origin", "Sydney, Australia"), ibox._html_items())
 
+    def test_tag_keeping(self):
+        ibox = dict(get_rendered_infoboxes("Black Sea")[0]._html_items())
+        self.assertEqual(ibox['Water volume'],
+                      u'547,000 km<sup>3</sup> (131,200 cu mi)',
+                      "Avoid stripping <sup> tags.")
+
+    def test_tag_stripping(self):
+        ibox = dict(get_rendered_infoboxes("Manchester")[0]._html_items())
+        self.assertEqual(ibox['Website'],
+                         u'www.manchester.gov.uk',
+                         "Avoid passing along links.")
+
+    def test_tag_annotation_stripping(self):
+        ibox = dict(get_rendered_infoboxes("Manchester")[0]._html_items())
+        self.assertEqual(ibox["GDP"], u'US$ 92.3 billion')
+        self.assertIn("Paul Murphy", ibox.values())
+
+        ibox = dict(get_rendered_infoboxes("Bill Clinton")[0]._html_items())
+        self.assertEqual(ibox['Religion'], u'Baptist (formerly Southern Baptist)')
+        self.assertEqual(ibox['Spouse(s)'],
+                         u'Hillary Rodham (<abbr title="married">m.</abbr>' +
+                         u' <abbr title="October 11, 1975">1975</abbr>)',
+                         'Keep abbreviations with their attributes.')
+
     def test_attributes(self):
         churchill = get_infoboxes("Winston Churchill")[0]
         self.assertIn("death-place", churchill.attributes)

--- a/tests/test_sort_symbols.py
+++ b/tests/test_sort_symbols.py
@@ -22,7 +22,7 @@ class TestSortSymbols(unittest.TestCase):
         symbols = ["Cake (TV series)", "Cake (firework)", "Cake (2005 film)",
                    "Cake", "Cake (band)", "Cake (advertisement)", "The Cake"]
 
-        expected = ["Cake (band)", "Cake (advertisement)", "Cake",
+        expected = ["Cake (band)", "Cake", "Cake (advertisement)",
                     "Cake (TV series)", "The Cake", "Cake (2005 film)",
                     "Cake (firework)"]
 

--- a/wikipediabase/fetcher.py
+++ b/wikipediabase/fetcher.py
@@ -72,9 +72,10 @@ class Fetcher(BaseFetcher):
         to True, the markup will be fetched from live wikipedia.org
 
         When tests are ran on TravisCI, we always want to use live data. We
-        check if Travis is running tests by looking at the TRAVIS env variable.
+        check if Travis is running tests by looking at the
+        WIKIPEDIABASE_FORCE_LIVE env variable.
         """
-        if force_live or os.getenv('TRAVIS', '') == 'true':
+        if force_live or os.getenv('WIKIPEDIABASE_FORCE_LIVE', '') == 'true':
             params = {'action': 'raw', 'title': symbol}
             page = self.urlopen(self.url, params)
 

--- a/wikipediabase/infobox.py
+++ b/wikipediabase/infobox.py
@@ -732,6 +732,13 @@ class InfoboxUtil:
     def parse_infobox_html(html_source):
         """
         Given the infobox html, return a list of (key, value) pairs.
+
+        Values may contain html that makes sense only in the context
+        of the infobox: inner <td> tags, <span> without the
+        corresponding css, and unqualified links. This list may or may
+        not be comprehensive, so it is safer to only allow text
+        formatting tags, lists, and line breaks and throw away
+        everything else.
         """
 
         ignoring_tags = ['ul', 'li', 'b', 'em', 'i', 'small', 'strong',

--- a/wikipediabase/infobox.py
+++ b/wikipediabase/infobox.py
@@ -734,18 +734,23 @@ class InfoboxUtil:
         Given the infobox html, return a list of (key, value) pairs.
         """
 
+        ignoring_tags = ['ul', 'li', 'b', 'em', 'i', 'small', 'strong',
+                         'sub', 'sup', 'ins', 'del', 'mark',]
         def escape_lists(val):
             if val is None:
                 return u""
 
-            return re.sub(
-                r"<\s*(/?\s*(br\s*/?|/?ul|/?li))\s*>", "&lt;\\1&gt;", val)
+            regex = r"<\s*(/?\s*(br\s*/?|/?%s))\s*>" % \
+                    r"|/?".join(ignoring_tags)
+
+            return re.sub(regex , "&lt;\\1&gt;", val)
 
         def unescape_lists(val):
             if val is None:
                 return u""
 
-            val = re.sub(r"&lt;(/?\s*(br\s*/?|ul|li))&gt;", "<\\1>", val)
+            val = re.sub(r"&lt;(/?\s*(br\s*/?|%s))&gt;" % \
+                         r"|".join(ignoring_tags), "<\\1>", val)
             return val
 
         soup = fromstring(html_source)


### PR DESCRIPTION
Infoboxes clean up the html of the values removing all tags but a few. Added some text formatting tags to the whitelist.

Fixes #88 
