### PR TITLE
Remove annotations before date parsing & prioritize

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+data/wikibase-term-*symbols filter=lfs diff=lfs merge=lfs -text
+data/wikibase-term-*synonyms filter=lfs diff=lfs merge=lfs -text

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script:
     - coverage run setup.py test
 after_success:
     - coveralls
+env:
+    - WIKIPEDIABASE_FORCE_LIVE=true

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Tests can then be run with:
 
     python setup.py test
 
+_Note: tests assume that you have set up the backend. To fetch from wikipedia.org instead of reading from the database, set the env variable `WIKIPEDIABASE_FORCE_LIVE=true`. This is strongly discouraged if you plan to use or contribute to WikipediaBase, as performance will be slow._
+
 ## API documentation
 
 Generate the documentation with:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 [![Build Status](https://travis-ci.org/infolab-csail/WikipediaBase.svg?branch=master)](https://travis-ci.org/infolab-csail/WikipediaBase)
 [![Stories in Ready](https://badge.waffle.io/infolab-csail/WikipediaBase.svg?label=ready&title=Ready)](http://waffle.io/infolab-csail/WikipediaBase)
-[![# of downloads](https://pypip.in/d/wikipediabase/badge.png)](https://crate.io/packages/wikipediabase?version=latest)
 [![Coverage Status](https://coveralls.io/repos/infolab-csail/WikipediaBase/badge.svg?branch=master&service=github)](https://coveralls.io/github/infolab-csail/WikipediaBase?branch=master)
 
 ## Overview
@@ -14,10 +13,14 @@ Wikipedia backend interface for
 [InfoLab's START](http://start.mit.edu). It answers s-expression
 queries via Telnet.
 
-## Usage
-Install `pip` and `gdbm` if not installed:
+## Documentation
 
-    apt-get install python-setuptools python-gdbm
+[API documentation](http://wikipediabase.rtfd.org)
+
+## Installing
+Install `pip` and `redis-server` if not installed:
+
+    apt-get install python-setuptools redis-server
 
 > Caution: Until wikipedibase is deployed on START installing it for non-testing purposes is not something one is supposed to do.
 
@@ -25,9 +28,31 @@ Install `wikipediabase`:
 
     python setup.py install
 
-## Documentation
+## Setting up the backend
 
-[API Documentation](http://wikipediabase.rtfd.org)
+1. Configure the backend. The scripts checks that Postgres and Redis are running, and creates the necessary tables.
+
+   ```
+   ./scripts/configure_db.py
+   ```
+
+   If Postgres throws `ERROR: new encoding (UTF8) is incompatible with the encoding of the template database (SQL_ASCII)`, follow [these](https://gist.github.com/ffmike/877447) instructions.
+
+1. Download the latest Wikipedia [dump](http://dumps.wikimedia.org/enwiki/).
+
+1. Create the backend. This step takes about 10 hours.
+
+   ```
+   bzcat /path/to/enwiki-YYYYMMDD-pages-articles.xml.bz2 | ./scripts/create_db.py
+   ```
+
+1. Generate symbols and synonyms (optional). This step takes about 40 hours.
+
+   ```
+   ./scripts/generate_symbols_and_synonyms.py
+   ```
+
+   Install [Git LFS](https://git-lfs.github.com/) and commit the changes to files in `data/`.
 
 ## Testing
 

--- a/data/wikibase-term-generated-synonyms
+++ b/data/wikibase-term-generated-synonyms
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4151c1f626936976e4be95e1c29d5f93d271decb45bea7434bc8d58d9108bc5
+size 563914871

--- a/data/wikibase-term-symbols
+++ b/data/wikibase-term-symbols
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5073dbb0e14ad5b82623a01372cf8f001f282393f9d291c3ea9e1d1c2a97b898
+size 97023360

--- a/scripts/generate_symbols_and_synonyms.py
+++ b/scripts/generate_symbols_and_synonyms.py
@@ -19,8 +19,8 @@ logging.basicConfig(filename='symbols.log', level=logging.DEBUG)
 logging.getLogger("peewee").setLevel(logging.WARNING)
 
 # TODO: change paths; pass in data_dir in sys.argv
-symbols_f = open('../data/wikibase-term-foo-symbols', 'w')
-synonyms_f = open('../data/wikibase-term-foo-generated-synonyms', 'w')
+symbols_f = open('../data/wikibase-term-symbols', 'w')
+synonyms_f = open('../data/wikibase-term-generated-synonyms', 'w')
 
 latest_symbols = LRUCache(100)
 

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -224,6 +224,11 @@ DEGENERATE_EXAMPLES = [
     # infobox defined outside the article, in its own template
     ('(get "wikipedia-military-conflict" "World War I" (:code "DATE"))',
      ('((:yyyymmdd 19140728))')),
+
+    ('(get "wikibase-person" "Wolfgang Amadeus Mozart" (:code "BIRTH-DATE"))',
+     '((:yyyymmdd 17560127))'),
+    ('(get "wikibase-person" "Ludwig van Beethoven" (:CODE "BIRTH-DATE"))',
+     '((:yyyymmdd 17701217))')
 ]
 
 WIKI_EXAMPLES_NOT = [

--- a/tests/test_sort_symbols.py
+++ b/tests/test_sort_symbols.py
@@ -22,7 +22,7 @@ class TestSortSymbols(unittest.TestCase):
         symbols = ["Cake (TV series)", "Cake (firework)", "Cake (2005 film)",
                    "Cake", "Cake (band)", "Cake (advertisement)", "The Cake"]
 
-        expected = ["Cake (band)", "Cake (advertisement)", "Cake",
+        expected = ["Cake (band)", "Cake", "Cake (advertisement)",
                     "Cake (TV series)", "The Cake", "Cake (2005 film)",
                     "Cake (firework)"]
 

--- a/wikipediabase/fetcher.py
+++ b/wikipediabase/fetcher.py
@@ -72,9 +72,10 @@ class Fetcher(BaseFetcher):
         to True, the markup will be fetched from live wikipedia.org
 
         When tests are ran on TravisCI, we always want to use live data. We
-        check if Travis is running tests by looking at the TRAVIS env variable.
+        check if Travis is running tests by looking at the
+        WIKIPEDIABASE_FORCE_LIVE env variable.
         """
-        if force_live or os.getenv('TRAVIS', '') == 'true':
+        if force_live or os.getenv('WIKIPEDIABASE_FORCE_LIVE', '') == 'true':
             params = {'action': 'raw', 'title': symbol}
             page = self.urlopen(self.url, params)
 


### PR DESCRIPTION
Annotations can be mixed up with dates. Overlay parse is smart enough to
avoid this kind for dates but not so much with date ranges. Just remove
them before parsing.

Also prefer dates based on precision.

Fixes #94 